### PR TITLE
unique ptr

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -89,6 +89,15 @@ int main() {
   t.rollback();
   assert(t.top() == 2);
 
+  t = {};
+  t.begin();
+  t.push(1);
+  t.begin();
+  t.push(2);
+  t.commit();
+  assert(t.pop() == 2);
+  assert(t.pop() == 1);
+
   printf("all tests passed\n");
   return 0;
 }


### PR DESCRIPTION
@patrick-schultz

Tests pass, but I think the ownership is wrong. You only know a transaction can be freed when it is neither 1) in the chain of reachable transactions (i.e. it's been rollback'd or commit'd) and 2) it does not own data reachable via reachable transactions.